### PR TITLE
fix: two committed Vote must have the same `voted_for`

### DIFF
--- a/suraft/src/storage/vote/mod.rs
+++ b/suraft/src/storage/vote/mod.rs
@@ -27,6 +27,15 @@ impl PartialOrd for Vote {
             cmp => return cmp,
         };
 
+        if self.committed {
+            assert_eq!(
+                self.voted_for, other.voted_for,
+                "there is at most one committed leader within a term: {}, \
+                but got {} and {}",
+                self.term, self.voted_for, other.voted_for
+            );
+        }
+
         if self.voted_for == other.voted_for {
             Some(Ordering::Equal)
         } else {


### PR DESCRIPTION

## Changelog

##### fix: two committed Vote must have the same `voted_for`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/suraft/suraft/9)
<!-- Reviewable:end -->
